### PR TITLE
Only marshal body if it is not nil

### DIFF
--- a/gthttp/httpclient.go
+++ b/gthttp/httpclient.go
@@ -216,8 +216,10 @@ func requestWithLimit(c *TogglHttpClient, method, endpoint string, b interface{}
 		return requestWithLimit(c, method, endpoint, b, attempt+1)
 	}
 
-	if body, err = json.Marshal(b); err != nil {
-		return nil, err
+	if b != nil {
+		if body, err = json.Marshal(b); err != nil {
+			return nil, err
+		}
 	}
 
 	req, err := http.NewRequest(method, endpoint, bytes.NewBuffer(body))


### PR DESCRIPTION
Currently, `TimeEntryClient.List` fails with a `stream error: stream ID 3; PROTOCOL_ERROR`.

This is because go marshals `nil` into the byte slice `null` and sends this as the request body of the `GET` request. By checking if `b` is not `nil` the request will be valid since it doesn't have a body.