### PR TITLE
Added isPrivate field to Project definition

### DIFF
--- a/gtproject/project.go
+++ b/gtproject/project.go
@@ -8,10 +8,11 @@ import (
 
 // Toggl Project Definition
 type Project struct {
-	Id   uint64 `json:"id"`
-	WId  uint64 `json:"wid"`
-	CId  uint64 `json:"cid"`
-	Name string `json:"name"`
+	Id        uint64 `json:"id"`
+	WId       uint64 `json:"wid"`
+	CId       uint64 `json:"cid"`
+	Name      string `json:"name"`
+	IsPrivate *bool  `json:"is_private,omitempty"`
 }
 
 type Projects []Project


### PR DESCRIPTION
This enables the user to create a public project. 

The field is a pointer to make sure that Toggl's default value `true` is used if the `is_private` field is not explicitly specified. 

https://github.com/toggl/toggl_api_docs/blob/master/chapters/projects.md#projects