### PR TITLE
Use new session cookie name

### DIFF
--- a/gthttp/httpclient.go
+++ b/gthttp/httpclient.go
@@ -19,7 +19,7 @@ const (
 	DefaultGzipEnabled        = false
 	DefaultUrl                = "https://www.toggl.com/api/v8"
 	DefaultVersion            = "v8"
-	SessionCookieName         = "toggl_api_session_new"
+	SessionCookieName         = "__Host-timer-session"
 	defaultBucket             = "toggl"
 	DefaultRateLimitPerSecond = 3
 )
@@ -187,11 +187,19 @@ func (c *TogglHttpClient) authenticate(key string) ([]byte, error) {
 		b, _ := ioutil.ReadAll(resp.Body)
 		return nil, &TogglError{Code: resp.StatusCode, Status: resp.Status, Msg: string(b)}
 	}
+
+	hasSessionCookie := false
 	for _, value := range resp.Cookies() {
 		if value.Name == SessionCookieName {
 			c.infoLog.Printf("Setting Cookie\n")
 			c.cookie = value
+			hasSessionCookie = true
+			break
 		}
+	}
+
+	if !hasSessionCookie {
+		return nil, fmt.Errorf("Auth cookie %q not found on authentication response", SessionCookieName)
 	}
 
 	return nil, nil

--- a/gthttp/httpclient_test.go
+++ b/gthttp/httpclient_test.go
@@ -29,7 +29,7 @@ var mockRequest = struct {
 var handler = func(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", mockRequest.contenttype)
 	if strings.Contains(r.URL.Path, "/sessions") {
-		w.Header().Set("Set-Cookie", "toggl_api_session_new=MTM2MzA4MJa8jA3OHxEdi1CQkFFQ180SUFBUkFCRUFBQVlQLUNBQUVHYzNSeWFXNW5EQXdBQ25ObGMzTnBiMjVmYVdRR2MzUnlhVzVuREQ0QVBIUnZaMmRzTFdGd2FTMXpaWE56YVc5dUxUSXRaalU1WmpaalpEUTVOV1ZsTVRoaE1UaGhaalpqWkRkbU5XWTJNV0psWVRnd09EWmlPVEV3WkE9PXweAkG7kI6NBG-iqvhNn1MSDhkz2Pz_UYTzdBvZjCaA==; Path=/; Expires=Wed, 13 Mar 2013 09:54:38 UTC; Max-Age=86400; HttpOnly")
+		w.Header().Set("Set-Cookie", "__Host-timer-session=MTM2MzA4MJa8jA3OHxEdi1CQkFFQ180SUFBUkFCRUFBQVlQLUNBQUVHYzNSeWFXNW5EQXdBQ25ObGMzTnBiMjVmYVdRR2MzUnlhVzVuREQ0QVBIUnZaMmRzTFdGd2FTMXpaWE56YVc5dUxUSXRaalU1WmpaalpEUTVOV1ZsTVRoaE1UaGhaalpqWkRkbU5XWTJNV0psWVRnd09EWmlPVEV3WkE9PXweAkG7kI6NBG-iqvhNn1MSDhkz2Pz_UYTzdBvZjCaA==; Path=/; Expires=Wed, 13 Mar 2013 09:54:38 UTC; Max-Age=86400; HttpOnly")
 		io.WriteString(w, "")
 	} else {
 		io.WriteString(w, mockRequest.body)
@@ -175,7 +175,7 @@ func Test404(t *testing.T) {
 	var h = func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", mockRequest.contenttype)
 		if strings.Contains(r.URL.Path, "/sessions") {
-			w.Header().Set("Set-Cookie", "toggl_api_session_new=MTM2MzA4MJa8jA3OHxEdi1CQkFFQ180SUFBUkFCRUFBQVlQLUNBQUVHYzNSeWFXNW5EQXdBQ25ObGMzTnBiMjVmYVdRR2MzUnlhVzVuREQ0QVBIUnZaMmRzTFdGd2FTMXpaWE56YVc5dUxUSXRaalU1WmpaalpEUTVOV1ZsTVRoaE1UaGhaalpqWkRkbU5XWTJNV0psWVRnd09EWmlPVEV3WkE9PXweAkG7kI6NBG-iqvhNn1MSDhkz2Pz_UYTzdBvZjCaA==; Path=/; Expires=Wed, 13 Mar 2013 09:54:38 UTC; Max-Age=86400; HttpOnly")
+			w.Header().Set("Set-Cookie", "__Host-timer-session=MTM2MzA4MJa8jA3OHxEdi1CQkFFQ180SUFBUkFCRUFBQVlQLUNBQUVHYzNSeWFXNW5EQXdBQ25ObGMzTnBiMjVmYVdRR2MzUnlhVzVuREQ0QVBIUnZaMmRzTFdGd2FTMXpaWE56YVc5dUxUSXRaalU1WmpaalpEUTVOV1ZsTVRoaE1UaGhaalpqWkRkbU5XWTJNV0psWVRnd09EWmlPVEV3WkE9PXweAkG7kI6NBG-iqvhNn1MSDhkz2Pz_UYTzdBvZjCaA==; Path=/; Expires=Wed, 13 Mar 2013 09:54:38 UTC; Max-Age=86400; HttpOnly")
 			io.WriteString(w, "")
 		} else {
 			w.WriteHeader(404)

--- a/test/gtest.go
+++ b/test/gtest.go
@@ -80,7 +80,7 @@ func (t *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Create mocked http.Response
 	response := &http.Response{Header: make(http.Header), Request: req, StatusCode: http.StatusOK}
 	response.Header.Set("Content-Type", "application/json")
-	response.Header.Set("Set-Cookie", "toggl_api_session_new=MTM2MzA4MJa8jA3OHxEdi1CQkFFQ180SUFBUkFCRUFBQVlQLUNBQUVHYzNSeWFXNW5EQXdBQ25ObGMzTnBiMjVmYVdRR2MzUnlhVzVuREQ0QVBIUnZaMmRzTFdGd2FTMXpaWE56YVc5dUxUSXRaalU1WmpaalpEUTVOV1ZsTVRoaE1UaGhaalpqWkRkbU5XWTJNV0psWVRnd09EWmlPVEV3WkE9PXweAkG7kI6NBG-iqvhNn1MSDhkz2Pz_UYTzdBvZjCaA==; Path=/; Expires=Wed, 13 Mar 2013 09:54:38 UTC; Max-Age=86400; HttpOnly")
+	response.Header.Set("Set-Cookie", "__Host-timer-session=MTM2MzA4MJa8jA3OHxEdi1CQkFFQ180SUFBUkFCRUFBQVlQLUNBQUVHYzNSeWFXNW5EQXdBQ25ObGMzTnBiMjVmYVdRR2MzUnlhVzVuREQ0QVBIUnZaMmRzTFdGd2FTMXpaWE56YVc5dUxUSXRaalU1WmpaalpEUTVOV1ZsTVRoaE1UaGhaalpqWkRkbU5XWTJNV0psWVRnd09EWmlPVEV3WkE9PXweAkG7kI6NBG-iqvhNn1MSDhkz2Pz_UYTzdBvZjCaA==; Path=/; Expires=Wed, 13 Mar 2013 09:54:38 UTC; Max-Age=86400; HttpOnly")
 	if strings.Contains(req.URL.Path, "/sessions") {
 		response.Body = ioutil.NopCloser(bytes.NewReader(nullResponse))
 		return response, nil


### PR DESCRIPTION
Toggle seems to have changed the session cookie name. This caused panics
while using this library. The following line in `requestWithLimit` adds
the session cookie regardless of the value. AddCookie panics when adding
a nil value.

     req.AddCookie(c.cookie)

Changed the session cookie name to the new name used by toggle.
Added a guard in the authenticate method that will error when the session
cookie is not found.