### PR TITLE
Add workspace ID to list projects method

### DIFF
--- a/gthttp/httpclient.go
+++ b/gthttp/httpclient.go
@@ -5,19 +5,20 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/throttled/throttled"
-	"github.com/throttled/throttled/store/memstore"
 	"io/ioutil"
 	"net/http"
 	"strconv"
 	"time"
+
+	"github.com/throttled/throttled"
+	"github.com/throttled/throttled/store/memstore"
 )
 
 const (
 	DefaultAuthPassword       = "api_token"
 	DefaultMaxRetries         = 5
 	DefaultGzipEnabled        = false
-	DefaultUrl                = "https://www.toggl.com/api/v8"
+	DefaultUrl                = "https://api.track.toggl.com/api/v8"
 	DefaultVersion            = "v8"
 	SessionCookieName         = "__Host-timer-session"
 	defaultBucket             = "toggl"

--- a/gtproject/project.go
+++ b/gtproject/project.go
@@ -3,6 +3,7 @@ package gtproject
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/dougEfresh/gtoggl-api/gthttp"
 )
 
@@ -35,8 +36,9 @@ type ProjectClient struct {
 	endpoint string
 }
 
-func (tc *ProjectClient) List() (Projects, error) {
-	body, err := tc.thc.GetRequest(tc.endpoint)
+// List returns all projects in a particular workspace.
+func (tc *ProjectClient) List(wid int) (Projects, error) {
+	body, err := tc.thc.GetRequest(fmt.Sprintf("%s/%s/%d/projects", tc.thc.Url, "workspaces", wid))
 	var projects []Project
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Hi!

Not sure when this changed, but in order to list projects you need to specify the workspace ID. See https://github.com/toggl/toggl_api_docs/blob/master/chapters/workspaces.md#get-workspace-projects for example usage.